### PR TITLE
#18 - preface: evaluate letf vs flet recursion performance

### DIFF
--- a/perf/Makefile
+++ b/perf/Makefile
@@ -1,10 +1,11 @@
+
 #
 # performance suite
 #
 .PHONY: help perf prep prof report base summary valgrind clean
 
 SHELL=/bin/bash
-NTESTS ?= 10
+NTESTS ?= 5
 LLVMTOOLSDIR = /System/Volumes/Data/Library/Developer/CommandLineTools/usr/bin
 
 help:
@@ -22,42 +23,44 @@ prep:
 	@rm -rf ./eko
 	@tar xfz ../dist/eko-0.0.1.tgz
 
+base:
+	@NTESTS=10 make perf
+	@cp mu-`date +"%m-%d-%y"`.perf mu-base.perf
+	@cp core-`date +"%m-%d-%y"`.perf core-base.perf
+	@cp nil-`date +"%m-%d-%y"`.perf nil-base.perf
+	@cp mapc-`date +"%m-%d-%y"`.perf mapc-base.perf
+	@cp forms-0-`date +"%m-%d-%y"`.perf forms-0-base.perf
+	@cp forms-1-`date +"%m-%d-%y"`.perf forms-1-base.perf
+	@cp forms-2-`date +"%m-%d-%y"`.perf forms-2-base.perf
+	@cp forms-3-`date +"%m-%d-%y"`.perf forms-3-base.perf
+	@cp letf-`date +"%m-%d-%y"`.perf letf-base.perf
+	@cp flet-`date +"%m-%d-%y"`.perf flet-base.perf
+
 perf: prep
-	@rm -f mu.out perf.out nil.out core.out mapc.out forms-0.out form-1.out forms-2.out
-	@for run in {1..$(NTESTS)}; do                   \
-           source ./preface-test.sh "(preface:time () ())" >> nil.out; \
-        done
-	@python3 mean.py nil.out > nil-`date +"%m-%d-%y"`.perf 
+	@rm -f *.out
+	@for run in {1..$(NTESTS)}; do		\
+           (source ./preface-test.sh "(preface:time () ())" >> nil.out ); 						\
+           (source ./preface-test.sh "(preface:time (mu:keysymp :t) ())" >> mu.out );					\
+           (source ./preface-test.sh "(preface:time (core:funcall mu:fixnum+ '(1 2)) ())" >> core.out ); 		\
+           (source ./preface-test.sh "(preface:time (core:mapc core:null ''(1 2 3 4 5 6)) ())" >> mapc.out ); 		\
+           (source ./preface-test.sh '(preface:time (core:load "./preface:forms-0.l" () ()) ())' >> forms-0.out ); 	\
+           (source ./preface-test.sh '(preface:time (core:load "./preface:forms-1.l" () ()) ())' >> forms-1.out ); 	\
+           (source ./preface-test.sh '(preface:time (core:load "./preface:forms-2.l" () ()) ())' >> forms-2.out ); 	\
+           (source ./preface-test.sh '(preface:time (core:load "./preface:forms-3.l" () ()) ())' >> forms-3.out ); 	\
+           (source ./preface-test.sh '(preface:time (core:load "./preface:flet.l" () ()) ())' >> flet.out ); 		\
+           (source ./preface-test.sh '(preface:time (core:load "./preface:letf.l" () ()) ())' >> letf.out );		\
+	done
 
-	@for run in {1..$(NTESTS)}; do                   \
-           source ./preface-test.sh "(preface:time (mu:keysymp :t) ())" >> mu.out; \
-        done
 	@python3 mean.py mu.out > mu-`date +"%m-%d-%y"`.perf 
-
-	@for run in {1..$(NTESTS)}; do                   \
-           source ./preface-test.sh "(preface:time (core:funcall mu:fixnum+ '(1 2)) ())" >> core.out; \
-        done
 	@python3 mean.py core.out > core-`date +"%m-%d-%y"`.perf 
-
-	@for run in {1..$(NTESTS)}; do                    \
-           source ./preface-test.sh "(preface:time (core:mapc core:null ''(1 2 3 4 5 6)) ())" >> mapc.out; \
-        done
 	@python3 mean.py mapc.out > mapc-`date +"%m-%d-%y"`.perf
-
-	@for run in {1..$(NTESTS)}; do                    \
-           source ./preface-test.sh '(preface:time (core:load "./preface:forms-0.l" () ()) ())' >> forms-0.out; \
-        done
 	@python3 mean.py forms-0.out > forms-0-`date +"%m-%d-%y"`.perf
-
-	@for run in {1..$(NTESTS)}; do                    \
-           source ./preface-test.sh '(preface:time (core:load "./preface:forms-1.l" () ()) ())' >> forms-1.out; \
-        done
 	@python3 mean.py forms-1.out > forms-1-`date +"%m-%d-%y"`.perf
-
-	@for run in {1..$(NTESTS)}; do                    \
-           source ./preface-test.sh '(preface:time (core:load "./preface:forms-2.l" () ()) ())' >> forms-2.out; \
-        done
 	@python3 mean.py forms-2.out > forms-2-`date +"%m-%d-%y"`.perf
+	@python3 mean.py forms-3.out > forms-3-`date +"%m-%d-%y"`.perf
+	@python3 mean.py flet.out > flet-`date +"%m-%d-%y"`.perf
+	@python3 mean.py letf.out > letf-`date +"%m-%d-%y"`.perf
+	@python3 mean.py nil.out > nil-`date +"%m-%d-%y"`.perf 
 
 report:
 	@echo ';;; per test average times (microseconds)'
@@ -75,20 +78,17 @@ report:
 	@diff forms-1-`date +"%m-%d-%y"`.perf forms-1-base.perf | grep -v -- --- | egrep -v '^[123456789]'
 	@echo ';;;' forms-2-`date +"%m-%d-%y"`.perf vs forms-2-base.perf
 	@diff forms-2-`date +"%m-%d-%y"`.perf forms-2-base.perf | grep -v -- --- | egrep -v '^[123456789]'
+	@echo ';;;' forms-3-`date +"%m-%d-%y"`.perf vs forms-3-base.perf
+	@diff forms-3-`date +"%m-%d-%y"`.perf forms-3-base.perf | grep -v -- --- | egrep -v '^[123456789]'
+	@echo ';;;' flet-`date +"%m-%d-%y"`.perf vs flet-base.perf
+	@diff flet-`date +"%m-%d-%y"`.perf flet-base.perf | grep -v -- --- | egrep -v '^[123456789]'
+	@echo ';;;' letf-`date +"%m-%d-%y"`.perf vs letf-base.perf
+	@diff letf-`date +"%m-%d-%y"`.perf letf-base.perf | grep -v -- --- | egrep -v '^[123456789]'
 	@echo
 	@echo ';;; per test object consumption'
-	@for i in nil mu core mapc forms-0 forms-1 forms-2; do	\
+	@for i in nil mu core mapc forms-0 forms-1 forms-2 forms-3 letf flet; do	\
 	    python3 summary.py $$i $$i.out;				\
 	done
-
-base:
-	@cp mu-`date +"%m-%d-%y"`.perf mu-base.perf
-	@cp core-`date +"%m-%d-%y"`.perf core-base.perf
-	@cp nil-`date +"%m-%d-%y"`.perf nil-base.perf
-	@cp mapc-`date +"%m-%d-%y"`.perf mapc-base.perf
-	@cp forms-0-`date +"%m-%d-%y"`.perf forms-0-base.perf
-	@cp forms-1-`date +"%m-%d-%y"`.perf forms-1-base.perf
-	@cp forms-2-`date +"%m-%d-%y"`.perf forms-2-base.perf
 
 prof: prep
 	@bash ./preface-test.sh '(preface:time (core:load "./preface:forms-2.l" () ()) ())'

--- a/perf/preface:flet.l
+++ b/perf/preface:flet.l
@@ -1,0 +1,5 @@
+(flet ((foo (foo n)
+         (cond
+           ((zerop n) 0)
+           (t (foo foo (1- n))))))
+  (foo foo 500))

--- a/perf/preface:forms-3.l
+++ b/perf/preface:forms-3.l
@@ -1,0 +1,8 @@
+(let ((foo (lambda () 1))) foo)
+(let ((foo (lambda () 1))) (foo))
+(letf ((foo () foo)) foo)
+(letf ((foo () foo)) (funcall foo))
+(letf ((foo () foo)) (foo))
+(letf* ((a-func () a-func)) a-func)
+(letf ((foo (sym) sym)) (foo foo))
+(letf ((foo (n) (cond ((zerop n) 0) (t (foo (1- n)))))) (foo 5))

--- a/perf/preface:letf.l
+++ b/perf/preface:letf.l
@@ -1,0 +1,1 @@
+(letf ((foo (n) (cond ((zerop n) 0) (t (foo (1- n)))))) (foo 500))

--- a/perf/summary.py
+++ b/perf/summary.py
@@ -17,9 +17,13 @@ labels = [
     "vectors"
 ]
 
+total_bytes = 0
+total_objs = 0
+
 print(f"{title:<10}", end="")
 for i in range(len(labels)):
-    if counts[i * 2 + 3] != "0":
-        print (f" {labels[i]}: {counts[i * 2 + 3]}/{counts[i * 2 + 2]}", end="")
-        
-print()
+    print (f"{labels[i]}: {counts[i * 2 + 3]}/{counts[i * 2 + 2]}\t", end="")
+    total_objs += int(counts[i * 2 + 3])
+    total_bytes += int(counts[i * 2 + 2])
+
+print (f"total: {total_objs}/{total_bytes}")

--- a/tests/preface:forms-3.l
+++ b/tests/preface:forms-3.l
@@ -1,4 +1,4 @@
-;:func:fixnum:func:func:func:func:func109876543210-1
+;:func:fixnum:func:func:func:func:func:t
 (mu:write (mu:type-of (let ((foo (lambda () 1))) foo)) mu:std-out ());:func
 (mu:write (mu:type-of (let ((foo (lambda () 1))) (foo))) mu:std-out ());:fixnum
 (mu:write (mu:type-of (letf ((foo () foo)) foo)) mu:std-out ());:func
@@ -6,4 +6,4 @@
 (mu:write (mu:type-of (letf ((foo () foo)) (foo))) mu:std-out ());:func
 (mu:write (mu:type-of (letf* ((a-func () a-func)) a-func)) mu:std-out ());:func
 (mu:write (mu:type-of (letf ((foo (sym) sym)) (foo foo))) mu:std-out ());:func
-(mu:write (letf ((count-down (n) (mu:write n mu:std-out :t) (if (zerop n) -1 (count-down (1- n))))) (count-down 10)) mu:std-out ());109876543210
+(mu:write (zerop (letf ((foo (n) (cond ((zerop n) 0) (t (foo (1- n)))))) (foo 5))) mu:std-out ());:t


### PR DESCRIPTION
Test cases for letf vs flet, revise perf measurement and reporting

;;; flet-07-20-22.perf vs flet-base.perf
< time(system)        :  134178.00    time(process)       :  134087.60
> time(system)        :  135750.10    time(process)       :  135518.70
;;; letf-07-20-22.perf vs letf-base.perf
< time(system)        :  132880.60    time(process)       :  132838.40
> time(system)        :  135033.30    time(process)       :  134922.90

letf  and flet are about the same speed, but letf conses fewer objects and ~25% fewer bytes for a simple recursive loop.

letf      conses: 2944/70656	functions: 28/1120	streams: 2/32	symbols: 2/64	vectors: 37/2440	total: 3013/74312
flet      conses: 3863/92712	functions: 20/800	streams: 1/16	symbols: 1/32	vectors: 28/1856	total: 3913/95416