### PR TITLE
#26 - libmu: revise tag structure

### DIFF
--- a/src/libmu/core/compile.cc
+++ b/src/libmu/core/compile.cc
@@ -46,7 +46,7 @@ namespace {
 
 /** * compile a list of forms **/
 Tag compile_list(Context &ctx, Tag list) {
-  assert(Cons::IsList(ctx.env, list));
+  assert(Cons::IsList(list));
 
   std::vector<Tag> vlist{};
 
@@ -59,7 +59,7 @@ Tag compile_list(Context &ctx, Tag list) {
 
 /** * is this symbol in the lexical environment? **/
 std::optional<std::pair<Tag, int>> map_lexical_symbol(Env &env, Tag sym) {
-  assert(Symbol::IsType(env, sym) || Symbol::IsKeyword(sym));
+  assert(Symbol::IsType(sym) || Symbol::IsKeyword(sym));
 
   if (Symbol::IsKeyword(sym))
     return std::nullopt;
@@ -81,12 +81,12 @@ std::optional<std::pair<Tag, int>> map_lexical_symbol(Env &env, Tag sym) {
 
 /** * parse lambda definition **/
 void parse_lambda(Env &env, Tag lambda) {
-  assert(Cons::IsList(env, lambda));
+  assert(Cons::IsList(lambda));
 
   std::vector<Tag> lexicals{};
 
   std::function<void(Env &, Tag)> parse = [&lexicals](Env &env, Tag symbol) {
-    if (!Symbol::IsType(env, symbol))
+    if (!Symbol::IsType(symbol))
       Exception::Raise(env, ":lambda", "error", "type", symbol);
 
     if (Symbol::IsKeyword(symbol))
@@ -121,7 +121,7 @@ Tag def_lambda(Context &ctx, Tag form) {
   Tag lambda = Cons::Nth(env, form, 1);
   Tag body = Cons::cdr(env, Cons::cdr(env, form));
 
-  if (!Cons::IsList(env, lambda))
+  if (!Cons::IsList(lambda))
     Exception::Raise(env, ":lambda", "error", "type", lambda);
 
   if (Type::Eq(Cons::car(env, lambda), Symbol::Keyword("quote")))
@@ -190,15 +190,15 @@ Tag Compile::frameid() { return Symbol::Keyword(std::to_string(frame_id++)); }
 Tag Compile::Form(Context &ctx, Tag form) {
   Env &env = ctx.env;
 
-  switch (Type::TypeOf(env, form)) {
+  switch (Type::TypeOf(form)) {
   case SYS_CLASS::CONS: { /* funcall/special call */
     Tag fn = Cons::car(env, form);
 
-    switch (Type::TypeOf(env, fn)) {
+    switch (Type::TypeOf(fn)) {
     case SYS_CLASS::CONS: { /* list, should compile to a function */
       Tag func = Form(ctx, fn);
 
-      if (!Function::IsType(ctx.env, func))
+      if (!Function::IsType(func))
         Exception::Raise(env, "compile", "error", "type", fn);
 
       return Cons(func, compile_list(ctx, Cons::cdr(env, form))).Heap(env);

--- a/src/libmu/core/context.cc
+++ b/src/libmu/core/context.cc
@@ -56,13 +56,13 @@ Tag Context::FrameToTag(Frame &fp) {
 }
 
 Tag Context::FuncIdOf(Tag frame) {
-  assert(Cons::IsType(env, frame));
+  assert(Cons::IsType(frame));
 
   return Cons::car(env, frame);
 }
 
 Tag Context::NthArgOf(Tag frame, size_t nth) {
-  assert(Cons::IsType(env, frame));
+  assert(Cons::IsType(frame));
 
   Tag argv = Cons::cdr(env, frame);
   assert(Vector::IsTyped(env, argv, SYS_CLASS::T));
@@ -72,7 +72,7 @@ Tag Context::NthArgOf(Tag frame, size_t nth) {
 
 // NOLINTNEXTLINE(bugprone-easily-swappable-parameters)
 void Context::SetNthArgOf(Tag frame, Tag value, size_t nth) {
-  assert(Cons::IsType(env, frame));
+  assert(Cons::IsType(frame));
 
   Tag argv = Cons::cdr(env, frame);
   assert(Vector::IsTyped(env, argv, SYS_CLASS::T));
@@ -81,10 +81,10 @@ void Context::SetNthArgOf(Tag frame, Tag value, size_t nth) {
 }
 
 Context::Frame *Context::TagToFrame(Tag frame) {
-  assert(Cons::IsType(env, frame));
+  assert(Cons::IsType(frame));
 
   Tag func = Cons::car(env, frame);
-  assert(Function::IsType(env, func));
+  assert(Function::IsType(func));
 
   Tag argv = Cons::cdr(env, frame);
   assert(Vector::IsTyped(env, argv, SYS_CLASS::T));
@@ -93,6 +93,7 @@ Context::Frame *Context::TagToFrame(Tag frame) {
 }
 
 Tag Context::CaptureContext() {
+
   std::vector<Tag> dynamic_{};
   for (auto fr : dynamic)
     dynamic_.push_back(FrameToTag(*fr));

--- a/src/libmu/core/env.cc
+++ b/src/libmu/core/env.cc
@@ -196,7 +196,7 @@ std::optional<Tag> Env::MapNamespace(const std::string &ns) const {
 
 /** * add namespace object to environment map **/
 void Env::AddNamespace(Tag ns) {
-  assert(Namespace::IsType(*this, ns));
+  assert(Namespace::IsType(ns));
 
   auto ns_name = Vector::StdStringOf(*this, Namespace::name(*this, ns));
   auto ns_iter = namespaces.find(ns_name);
@@ -224,8 +224,8 @@ void Env::Gc(Env &env, Tag ptr) {
       {SYS_CLASS::SYMBOL, type::Symbol::Gc},
       {SYS_CLASS::VECTOR, type::Vector::Gc}};
 
-  assert(kGcTypeMap.contains(Type::TypeOf(env, ptr)));
-  kGcTypeMap.at(Type::TypeOf(env, ptr))(env, ptr);
+  assert(kGcTypeMap.contains(Type::TypeOf(ptr)));
+  kGcTypeMap.at(Type::TypeOf(ptr))(env, ptr);
 }
 
 /** * env constructor **/

--- a/src/libmu/core/eval.cc
+++ b/src/libmu/core/eval.cc
@@ -51,7 +51,7 @@ using Frame = Context::Frame;
 
 /** * call function with argument vector **/
 Tag Env::Funcall(Context &ctx, Tag func, const std::vector<Tag> &argv) {
-  assert(Function::IsType(ctx.env, func));
+  assert(Function::IsType(func));
 
   Env &env = ctx.env;
   size_t nreqs = Fixnum::Int64Of(Function::arity(env, func));
@@ -66,7 +66,7 @@ Tag Env::Funcall(Context &ctx, Tag func, const std::vector<Tag> &argv) {
   Frame fp = Frame(func, const_cast<Tag *>(argv.data()));
   Tag fn = Function::form(env, func);
 
-  if (Symbol::IsType(env, fn)) {
+  if (Symbol::IsType(fn)) {
     ctx.DynamicContextPush(fp);
     env.fn_cache->at(fn)(ctx, fp);
     ctx.DynamicContextPop();
@@ -74,7 +74,7 @@ Tag Env::Funcall(Context &ctx, Tag func, const std::vector<Tag> &argv) {
     return fp.value;
   }
 
-  if (!Cons::IsType(env, fn))
+  if (!Cons::IsType(fn))
     throw std::runtime_error("funcall type");
 
   ctx.DynamicContextPush(fp);
@@ -99,19 +99,19 @@ Tag Env::Funcall(Context &ctx, Tag func, const std::vector<Tag> &argv) {
 Tag Env::Eval(Context &ctx, Tag form) {
   Env &env = ctx.env;
 
-  if (Symbol::IsType(ctx.env, form)) {
+  if (Symbol::IsType(form)) {
     if (!Symbol::IsBound(env, form))
       Exception::Raise(env, "eval", "error", "unbound", form);
 
     return Symbol::value(env, form);
   }
 
-  if (!Cons::IsType(env, form))
+  if (!Cons::IsType(form))
     return form;
 
   Tag fn = Cons::car(env, form);
 
-  if (Symbol::IsType(env, fn)) {
+  if (Symbol::IsType(fn)) {
     if (Type::Eq(fn, Symbol::Keyword("quote")))
       return Cons::Nth(env, form, 1);
 
@@ -126,11 +126,11 @@ Tag Env::Eval(Context &ctx, Tag form) {
       Exception::Raise(env, "eval", "error", "unbound", fn);
 
     fn = Symbol::value(env, fn);
-  } else if (Cons::IsType(env, form)) {
+  } else if (Cons::IsType(form)) {
     fn = Eval(ctx, fn);
   }
 
-  if (!Function::IsType(env, fn))
+  if (!Function::IsType(fn))
     Exception::Raise(env, "eval", "error", "type", fn);
 
   Tag args = Cons::cdr(env, form);

--- a/src/libmu/core/heap.cc
+++ b/src/libmu/core/heap.cc
@@ -40,7 +40,7 @@ namespace core {
 /** * convert tag to uint64_t **/
 void *Heap::LayoutAddr(Env &env, Tag ptr) {
 
-  return env.heap->HeapAddr(std::to_underlying(ptr) & ~0x7);
+  return env.heap->HeapAddr(Type::IndirectData(ptr));
 }
 
 /** * garbage collection **/

--- a/src/libmu/core/heap.h
+++ b/src/libmu/core/heap.h
@@ -62,22 +62,9 @@ public:
     return HeapInfo((HeapWords(size) << 16) | std::to_underlying(tag));
   }
 
-  /** * SYS_CLASS from tag **/
-  Type::SYS_CLASS SysClass(Env &, Type::Tag ptr) {
-    HeapInfo hinfo = *Map(ptr);
-
-    return SysClass(hinfo);
-  }
-
   /** * SYS_CLASS from HeapInfo **/
   static Type::SYS_CLASS SysClass(HeapInfo hinfo) {
     return Type::SYS_CLASS(std::to_underlying(hinfo) & 0xff);
-  }
-
-  /** * HeapInfo from HeapInfo, SYS_CLASS **/
-  static HeapInfo SysClass(HeapInfo hinfo, Type::SYS_CLASS tag) {
-    return HeapInfo((std::to_underlying(hinfo) & ~uint64_t{0xff}) |
-                    std::to_underlying(tag));
   }
 
   /** * get/set ref bits **/

--- a/src/libmu/core/print.cc
+++ b/src/libmu/core/print.cc
@@ -53,7 +53,7 @@ namespace {
 void print_as_broket(Env &env, Tag object, Tag stream) {
 
   std::string type = Vector::StdStringOf(
-      env, Symbol::name(env, Type::MapClassSymbol(Type::TypeOf(env, object))));
+      env, Symbol::name(env, Type::MapClassSymbol(Type::TypeOf(object))));
   std::stringstream hexs;
 
   hexs << std::hex << std::to_underlying(object);
@@ -64,7 +64,7 @@ void print_as_broket(Env &env, Tag object, Tag stream) {
 
 /** * print std::string to stream **/
 void Env::Write(Env &env, const std::string &str, Tag stream, bool esc) {
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   if (esc)
     Write(env, "\"", stream, false);
@@ -90,8 +90,8 @@ void Env::Write(Env &env, Tag object, Tag stream, bool esc) {
                 {SYS_CLASS::SYMBOL, Symbol::Write},
                 {SYS_CLASS::VECTOR, Vector::Write}};
 
-  if (kWriteMap.contains(Type::TypeOf(env, object)))
-    kWriteMap.at(Type::TypeOf(env, object))(env, object, stream, esc);
+  if (kWriteMap.contains(Type::TypeOf(object)))
+    kWriteMap.at(Type::TypeOf(object))(env, object, stream, esc);
   else
     print_as_broket(env, object, stream);
 }

--- a/src/libmu/core/read.cc
+++ b/src/libmu/core/read.cc
@@ -62,7 +62,7 @@ bool is_char_syntax_char(Tag ch, SYNTAX_CHAR syntax_char) {
 
 /** * read atom **/
 std::string read_atom(Env &env, Tag stream) {
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   std::string string{};
 
@@ -113,7 +113,7 @@ std::optional<Tag> parse_number(Env &env, const std::string &str) {
 
 /** * read radixed fixnum from stream **/
 Tag radix_fixnum(Env &env, int radix, Tag stream) {
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   std::string str = read_atom(env, stream);
 
@@ -141,7 +141,7 @@ Tag radix_fixnum(Env &env, int radix, Tag stream) {
 
 /** * absorb whitespace until eof **/
 bool Env::ReadWSUntilEof(Env &env, Tag stream) {
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   Tag ch;
 
@@ -162,7 +162,7 @@ bool Env::ReadWSUntilEof(Env &env, Tag stream) {
 
 /** * read form **/
 Tag Env::Read(Env &env, Tag stream) {
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   if (!ReadWSUntilEof(env, stream))
     return Type::NIL;
@@ -182,7 +182,7 @@ Tag Env::Read(Env &env, Tag stream) {
       return ReadTable::MakeSyntax(ch);
     case SYNTAX_CHAR::QUOTE: { /* quote syntax */
       Tag quoted = Read(env, stream);
-      return Symbol::IsType(env, quoted) || Cons::IsType(env, quoted)
+      return Symbol::IsType(quoted) || Cons::IsType(quoted)
                  ? Cons::List(
                        env, std::vector<Tag>{Symbol::Keyword("quote"), quoted})
                  : quoted;

--- a/src/libmu/core/type.cc
+++ b/src/libmu/core/type.cc
@@ -73,8 +73,8 @@ Tag Type::View(Env &env, Tag object) {
       {SYS_CLASS::STREAM, Stream::View},
       {SYS_CLASS::VECTOR, Vector::View}};
 
-  return kViewMap.contains(Type::TypeOf(env, object))
-             ? kViewMap.at(Type::TypeOf(env, object))(env, object)
+  return kViewMap.contains(Type::TypeOf(object))
+             ? kViewMap.at(Type::TypeOf(object))(env, object)
              : Type::NIL;
 }
 
@@ -116,7 +116,7 @@ Tag Type::MapClassSymbol(SYS_CLASS sys_class) {
 }
 
 /** * type of tagged pointer **/
-SYS_CLASS Type::TypeOf(Env &env, Tag ptr) {
+SYS_CLASS Type::TypeOf(Tag ptr) {
 
   switch (TagOf(ptr)) {
   case TAG::CONS:
@@ -124,7 +124,7 @@ SYS_CLASS Type::TypeOf(Env &env, Tag ptr) {
   case TAG::DIRECT:
     return SYS_CLASS(DirectClass(ptr));
   case TAG::INDIRECT:
-    return SYS_CLASS(Heap::SysClass(*env.heap->Map(ptr)));
+    return IndirectClass(ptr);
   case TAG::UNUSED:
     [[fallthrough]];
   default:

--- a/src/libmu/env/env-context.cc
+++ b/src/libmu/env/env-context.cc
@@ -61,10 +61,10 @@ void BindContext(Context &ctx, Frame &fp) {
   Tag fn = fp.argv[0];
   Tag vctx = fp.argv[1];
 
-  if (!Function::IsType(ctx.env, fn))
+  if (!Function::IsType(fn))
     Exception::Raise(ctx.env, "bind", "error", "type", fn);
 
-  if (!Cons::IsList(ctx.env, vctx))
+  if (!Cons::IsList(vctx))
     Exception::Raise(ctx.env, "bind", "error", "type", vctx);
 
   ctx.thread = std::make_unique<std::thread>([&ctx, &fn]() {
@@ -82,7 +82,7 @@ void BindContext(Context &ctx, Frame &fp) {
 void ResumeContext(Context &ctx, Frame &fp) {
   Tag vctx = fp.argv[0];
 
-  if (!Cons::IsType(ctx.env, vctx))
+  if (!Cons::IsType(vctx))
     Exception::Raise(ctx.env, "resume", "error", "type", vctx);
 
   fp.value = Type::T;
@@ -95,14 +95,14 @@ void SuspendContext(Context &, Frame &fp) { fp.value = fp.argv[0]; }
 void ContextFix(Context &ctx, Frame &fp) {
   fp.value = fp.argv[0];
 
-  if (!Function::IsType(ctx.env, fp.value))
+  if (!Function::IsType(fp.value))
     Exception::Raise(ctx.env, "ctx-fix", "error", "type", fp.value);
 
   std::vector<Tag> noargs{};
 
   for (;;) {
     fp.value = Env::Funcall(ctx, fp.value, noargs);
-    if (!type::Function::IsType(ctx.env, fp.value))
+    if (!type::Function::IsType(fp.value))
       break;
   }
 }

--- a/src/libmu/env/env-frame.cc
+++ b/src/libmu/env/env-frame.cc
@@ -64,7 +64,7 @@ void FrameGet(Context &ctx, Frame &fp) {
 
   Tag fn = fp.argv[0];
 
-  if (!Function::IsType(ctx.env, fn))
+  if (!Function::IsType(fn))
     Exception::Raise(ctx.env, "fnv-lex", "error", "type", fn);
 
   std::optional<Frame *> fstate =
@@ -83,7 +83,7 @@ void FrameSetVar(Context &ctx, Frame &fp) {
   Tag off = fp.argv[1];
   Tag value = fp.argv[2];
 
-  if (!Cons::IsType(ctx.env, fr))
+  if (!Cons::IsType(fr))
     Exception::Raise(ctx.env, "fnv-set", "error", "type", fr);
 
   if (!Fixnum::IsType(off))
@@ -100,7 +100,7 @@ void FrameSet(Context &ctx, Frame &fp) {
   Tag off = fp.argv[1];
   Tag value = fp.argv[2];
 
-  if (!Function::IsType(ctx.env, fn))
+  if (!Function::IsType(fn))
     Exception::Raise(ctx.env, "lex-set", "error", "type", fn);
 
   if (!Fixnum::IsType(off))
@@ -120,7 +120,7 @@ void FrameSet(Context &ctx, Frame &fp) {
 void FramePush(Context &ctx, Frame &fp) {
   Tag fr = fp.argv[0];
 
-  if (!Cons::IsType(ctx.env, fr))
+  if (!Cons::IsType(fr))
     Exception::Raise(ctx.env, "fr-push", "error", "type", fr);
 
   Frame *frame = ctx.TagToFrame(fr);
@@ -134,7 +134,7 @@ void FramePush(Context &ctx, Frame &fp) {
 void FramePop(Context &ctx, Frame &fp) {
   Tag fr = fp.argv[0];
 
-  if (!Cons::IsType(ctx.env, fr))
+  if (!Cons::IsType(fr))
     Exception::Raise(ctx.env, "fr-pop", "error", "type", fr);
 
   delete ctx.closures[fr].back();

--- a/src/libmu/env/env-namespace.cc
+++ b/src/libmu/env/env-namespace.cc
@@ -63,7 +63,7 @@ void MapNamespace(Context &ctx, Frame &fp) {
 void Namespace(Context &ctx, Frame &fp) {
   Tag ns = fp.argv[0];
 
-  if (!Namespace::IsType(ctx.env, ns))
+  if (!Namespace::IsType(ns))
     Exception::Raise(ctx.env, "ns", "error", "type", ns);
 
   fp.value = ns;

--- a/src/libmu/heap/heap-mapped.cc
+++ b/src/libmu/heap/heap-mapped.cc
@@ -113,7 +113,7 @@ std::optional<size_t> Mapped::Alloc(int nbytes, SYS_CLASS tag) {
   n_objects++;
   type_alloc->at(std::to_underlying(tag))++;
 
-  return heap_addr - reinterpret_cast<size_t>(halloc + size_t{1});
+  return heap_addr - reinterpret_cast<size_t>(halloc + 1);
 }
 
 /** * count up total data bytes in heap **/

--- a/src/libmu/heap/mapped.h
+++ b/src/libmu/heap/mapped.h
@@ -83,19 +83,18 @@ public:
 
   /** * maps **/
   HeapInfo *Map(Tag ptr) override {
-    return reinterpret_cast<HeapInfo *>(
-               HeapAddr(std::to_underlying(ptr) & ~3)) -
-           1;
+    return reinterpret_cast<HeapInfo *>(HeapAddr(Type::IndirectData(ptr) - 1));
   }
 
   void Map(std::function<void(HeapInfo *)> fn) override {
+
     heapinfo_iter iter(this);
     for (auto it = iter.begin(); it != iter.end(); it = ++iter)
       fn(it);
   }
 
-  /** * tag offset is -1 * byte offset */
   void *HeapAddr(size_t offset) override {
+
     // NOLINTNEXTLINE(performance-no-int-to-ptr)
     return reinterpret_cast<void *>(heap_addr - offset);
   }

--- a/src/libmu/libmu.cc
+++ b/src/libmu/libmu.cc
@@ -57,7 +57,7 @@ uint64_t mu_read_stream(void *ctx, uint64_t stream) {
     stream =
         std::to_underlying(Symbol::value(ctxt->env, ctxt->env.standard_input));
 
-  if (!Stream::IsType(ctxt->env, Tag(stream))) {
+  if (!Stream::IsType(Tag(stream))) {
     throw std::runtime_error("stream type\n");
   }
 

--- a/src/libmu/mu/mu-cons.cc
+++ b/src/libmu/mu/mu-cons.cc
@@ -44,7 +44,7 @@ namespace mu {
 void ListLength(Context &ctx, Frame &fp) {
   Tag list = fp.argv[0];
 
-  if (!Cons::IsList(ctx.env, list))
+  if (!Cons::IsList(list))
     Exception::Raise(ctx.env, "length", "error", "type", list);
 
   fp.value = Fixnum(Cons::Length(ctx.env, list)).tag_;
@@ -59,7 +59,7 @@ void Cons(Context &ctx, Frame &fp) {
 void Car(Context &ctx, Frame &fp) {
   Tag list = fp.argv[0];
 
-  if (!Cons::IsList(ctx.env, list))
+  if (!Cons::IsList(list))
     Exception::Raise(ctx.env, "car", "error", "type", list);
 
   fp.value = Cons::car(ctx.env, list);
@@ -69,7 +69,7 @@ void Car(Context &ctx, Frame &fp) {
 void Cdr(Context &ctx, Frame &fp) {
   Tag list = fp.argv[0];
 
-  if (!Cons::IsList(ctx.env, list))
+  if (!Cons::IsList(list))
     Exception::Raise(ctx.env, "cdr", "error", "type", list);
 
   fp.value = Cons::cdr(ctx.env, list);
@@ -86,7 +86,7 @@ void Nth(Context &ctx, Frame &fp) {
   if (Fixnum::Int64Of(nth) < 0)
     Exception::Raise(ctx.env, "nth", "error", "type", nth);
 
-  if (!Cons::IsList(ctx.env, list))
+  if (!Cons::IsList(list))
     Exception::Raise(ctx.env, "nth", "error", "type", list);
 
   fp.value = Cons::Nth(ctx.env, list, Fixnum::Int64Of(nth));
@@ -100,12 +100,12 @@ void Nthcdr(Context &ctx, Frame &fp) {
   if (!Fixnum::IsType(index) || Fixnum::Int64Of(index) < 0)
     Exception::Raise(ctx.env, "nthcdr", "error", "type", index);
 
-  if (!Cons::IsList(ctx.env, list))
+  if (!Cons::IsList(list))
     Exception::Raise(ctx.env, "nthcdr", "error", "type", list);
 
   uint64_t nth = Fixnum::Int64Of(index);
 
-  if (!Cons::IsList(ctx.env, Cons::cdr(ctx.env, list))) {
+  if (!Cons::IsList(Cons::cdr(ctx.env, list))) {
     if (nth > 1)
       Exception::Raise(ctx.env, "nthcdr", "error", "range", index);
 

--- a/src/libmu/mu/mu-core.cc
+++ b/src/libmu/mu/mu-core.cc
@@ -44,10 +44,10 @@ using Vector = type::Vector;
 namespace mu {
 
 /** * (type-of object) => symbol **/
-void TypeOf(Context &ctx, Frame &fp) {
+void TypeOf(Context &, Frame &fp) {
   Tag obj = fp.argv[0];
 
-  fp.value = Type::MapClassSymbol(Type::TypeOf(ctx.env, obj));
+  fp.value = Type::MapClassSymbol(Type::TypeOf(obj));
 }
 
 /** * (eq object object) => bool **/

--- a/src/libmu/mu/mu-exception.cc
+++ b/src/libmu/mu/mu-exception.cc
@@ -37,7 +37,7 @@ namespace mu {
 [[noreturn]] void RaiseException(Context &ctx, Frame &fp) {
   Tag exception = fp.argv[0];
 
-  if (!Exception::IsType(ctx.env, exception))
+  if (!Exception::IsType(exception))
     Exception::Raise(ctx.env, "ex-rais", "error", "type", exception);
 
   fp.value = exception;
@@ -70,10 +70,10 @@ void WithException(Context &ctx, Frame &fp) {
 
   auto mark = ctx.dynamic.size();
 
-  if (!Function::IsType(ctx.env, thunk))
+  if (!Function::IsType(thunk))
     Exception::Raise(ctx.env, "with-ex", "error", "type", thunk);
 
-  if (!Function::IsType(ctx.env, handler))
+  if (!Function::IsType(handler))
     Exception::Raise(ctx.env, "with-ex", "error", "type", handler);
 
   Type::Tag value;

--- a/src/libmu/mu/mu-function.cc
+++ b/src/libmu/mu/mu-function.cc
@@ -45,10 +45,10 @@ void Funcall(Context &ctx, Frame &fp) {
   Tag func = fp.argv[0];
   Tag args = fp.argv[1];
 
-  if (!(Function::IsType(ctx.env, func)))
+  if (!(Function::IsType(func)))
     Exception::Raise(ctx.env, "funcall", "error", "type", func);
 
-  if (!(Cons::IsList(ctx.env, args)))
+  if (!(Cons::IsList(args)))
     Exception::Raise(ctx.env, "funcall", "error", "type", args);
 
   std::vector<Type::Tag> argv;
@@ -63,7 +63,7 @@ void Funcall(Context &ctx, Frame &fp) {
 void FunctionClone(Context &ctx, Frame &fp) {
   Tag vector = fp.argv[0];
 
-  if (!Vector::IsType(ctx.env, vector))
+  if (!Vector::IsType(vector))
     Exception::Raise(ctx.env, "clone", "error", "type", vector);
 
   fp.value = Function::Clone(ctx.env, vector);
@@ -80,7 +80,7 @@ void FunctionInt(Context &ctx, Frame &fp) {
                        {Symbol::Keyword("form"), Function::form},
                        {Symbol::Keyword("frame"), Function::frame_id}};
 
-  if (!Function::IsType(ctx.env, fn))
+  if (!Function::IsType(fn))
     Exception::Raise(ctx.env, "fn-int", "error", "type", fn);
 
   if (!Symbol::IsKeyword(keyword))

--- a/src/libmu/mu/mu-namespace.cc
+++ b/src/libmu/mu/mu-namespace.cc
@@ -47,7 +47,7 @@ namespace mu {
 void NameOfNamespace(Context &ctx, Frame &fp) {
   Tag ns = Namespace::NsDesignator(ctx.env, fp.argv[0]);
 
-  if (!Namespace::IsType(ctx.env, ns))
+  if (!Namespace::IsType(ns))
     Exception::Raise(ctx.env, "name-ns", "error", "type", ns);
 
   fp.value = Namespace::name(ctx.env, ns);
@@ -57,7 +57,7 @@ void NameOfNamespace(Context &ctx, Frame &fp) {
 void ImportOfNamespace(Context &ctx, Frame &fp) {
   Tag ns = Namespace::NsDesignator(ctx.env, fp.argv[0]);
 
-  if (!Namespace::IsType(ctx.env, ns))
+  if (!Namespace::IsType(ns))
     Exception::Raise(ctx.env, "name-ns", "error", "type", ns);
 
   fp.value = Namespace::import(ctx.env, ns);
@@ -68,10 +68,10 @@ void NamespaceSymbols(Context &ctx, Frame &fp) {
   Tag ns = Namespace::NsDesignator(ctx.env, fp.argv[0]);
   Tag type = fp.argv[1];
 
-  if (!Namespace::IsType(ctx.env, ns))
+  if (!Namespace::IsType(ns))
     Exception::Raise(ctx.env, "ns-syms", "error", "type", ns);
 
-  if (!Symbol::IsType(ctx.env, type) || !Symbol::IsKeyword(type))
+  if (!Symbol::IsType(type))
     Exception::Raise(ctx.env, "ns-syms", "error", "type", type);
 
   std::vector<Type::Tag> symbols{};
@@ -90,7 +90,7 @@ void MapNamespace(Context &ctx, Frame &fp) {
   Tag type = fp.argv[1];
   Tag name = fp.argv[2];
 
-  if (!Namespace::IsType(ctx.env, ns))
+  if (!Namespace::IsType(ns))
     Exception::Raise(ctx.env, "ns-find", "error", "type", ns);
 
   if (!Vector::IsTyped(ctx.env, name, Type::SYS_CLASS::CHAR))
@@ -114,7 +114,7 @@ void Intern(Context &ctx, Frame &fp) {
   Tag type = fp.argv[1];
   Tag name = fp.argv[2];
 
-  if (!Namespace::IsType(ctx.env, Namespace::NsDesignator(ctx.env, ns)))
+  if (!Namespace::IsType(Namespace::NsDesignator(ctx.env, ns)))
     Exception::Raise(ctx.env, "intern", "error", "type", ns);
 
   if (!Vector::IsTyped(ctx.env, name, Type::SYS_CLASS::CHAR))
@@ -137,7 +137,7 @@ void InternValue(Context &ctx, Frame &fp) {
   Tag name = fp.argv[2];
   Tag value = fp.argv[3];
 
-  if (!Namespace::IsType(ctx.env, Namespace::NsDesignator(ctx.env, ns)))
+  if (!Namespace::IsType(Namespace::NsDesignator(ctx.env, ns)))
     Exception::Raise(ctx.env, ":intern", "error", "type", ns);
 
   if (!Vector::IsTyped(ctx.env, name, Type::SYS_CLASS::CHAR))
@@ -159,7 +159,7 @@ void MakeNamespace(Context &ctx, Frame &fp) {
   if (!Vector::IsTyped(ctx.env, name, Type::SYS_CLASS::CHAR))
     Exception::Raise(ctx.env, "ns", "error", "type", name);
 
-  if (!Namespace::IsType(ctx.env, import) && !Type::Null(import))
+  if (!Namespace::IsType(import) && !Type::Null(import))
     Exception::Raise(ctx.env, "ns", "error", "type", import);
 
   fp.value = type::Namespace(name, import).Heap(ctx.env);

--- a/src/libmu/mu/mu-printer.cc
+++ b/src/libmu/mu/mu-printer.cc
@@ -56,7 +56,7 @@ void Write(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[1];
   Tag escape = fp.argv[2];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "write", "error", "type", stream);
 
   Env::Write(ctx.env, obj, stream, !Type::Null(escape));

--- a/src/libmu/mu/mu-reader.cc
+++ b/src/libmu/mu/mu-reader.cc
@@ -52,7 +52,7 @@ namespace mu {
 void Read(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[0];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "read", "error", "type", stream);
 
   if (Stream::IsEof(ctx.env, stream))

--- a/src/libmu/mu/mu-stream.cc
+++ b/src/libmu/mu/mu-stream.cc
@@ -54,7 +54,7 @@ namespace mu {
 void IsEof(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[0];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "eofp", "error", "type", fp.argv[0]);
 
   fp.value = Type::Bool(Stream::IsEof(ctx.env, stream));
@@ -68,7 +68,7 @@ void UnReadByte(Context &ctx, Frame &fp) {
   if (!Fixnum::IsType(ch))
     Exception::Raise(ctx.env, "un-byte", "error", "type", ch);
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "un-byte", "error", "type", fp.argv[1]);
 
   fp.value = Stream::UnReadByte(ctx.env, ch, stream);
@@ -82,7 +82,7 @@ void UnReadChar(Context &ctx, Frame &fp) {
   if (!Char::IsType(ch))
     Exception::Raise(ctx.env, "un-char", "error", "type", ch);
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "un-char", "error", "type", fp.argv[1]);
 
   fp.value = Stream::UnReadChar(ctx.env, ch, stream);
@@ -92,7 +92,7 @@ void UnReadChar(Context &ctx, Frame &fp) {
 void ReadByte(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[0];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "rd-byte", "error", "ftype", fp.argv[0]);
 
   fp.value = Stream::ReadByte(ctx.env, stream);
@@ -102,7 +102,7 @@ void ReadByte(Context &ctx, Frame &fp) {
 void ReadChar(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[0];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "rd-byte", "error", "ftype", fp.argv[0]);
 
   fp.value = Stream::ReadChar(ctx.env, stream);
@@ -116,7 +116,7 @@ void WriteByte(Context &ctx, Frame &fp) {
   if (!Fixnum::IsType(byte))
     Exception::Raise(ctx.env, "wr-byte", "error", "type", byte);
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "wr-byte", "error", "type", stream);
 
   Stream::WriteByte(ctx.env, byte, stream);
@@ -132,7 +132,7 @@ void WriteChar(Context &ctx, Frame &fp) {
   if (!Char::IsType(ch))
     Exception::Raise(ctx.env, "wr-char", "error", "type", ch);
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "wr-char", "error", "type", stream);
 
   Stream::WriteChar(ctx.env, ch, stream);
@@ -193,7 +193,7 @@ void OpenStream(Context &ctx, Frame &fp) {
 void GetStringStream(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[0];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "get-str", "error", "type", stream);
 
   if (!Stream::stream(ctx.env, stream)->IsString())
@@ -207,7 +207,7 @@ void GetStringStream(Context &ctx, Frame &fp) {
 void Close(Context &ctx, Frame &fp) {
   Tag stream = fp.argv[0];
 
-  if (!Stream::IsType(ctx.env, stream))
+  if (!Stream::IsType(stream))
     Exception::Raise(ctx.env, "close", "error", "type", stream);
 
   Stream::Close(ctx.env, stream);

--- a/src/libmu/mu/mu-symbol.cc
+++ b/src/libmu/mu/mu-symbol.cc
@@ -41,7 +41,7 @@ namespace mu {
 void SymbolValue(Context &ctx, Frame &fp) {
   Tag symbol = fp.argv[0];
 
-  if (!Symbol::IsType(ctx.env, symbol))
+  if (!Symbol::IsType(symbol))
     Exception::Raise(ctx.env, "sy-val", "error", "type", symbol);
 
   if (!Symbol::IsBound(ctx.env, symbol))
@@ -54,7 +54,7 @@ void SymbolValue(Context &ctx, Frame &fp) {
 void SymbolName(Context &ctx, Frame &fp) {
   Tag symbol = fp.argv[0];
 
-  if (!Symbol::IsType(ctx.env, symbol))
+  if (!Symbol::IsType(symbol))
     Exception::Raise(ctx.env, "sy-name", "error", "type", symbol);
 
   fp.value = Symbol::name(ctx.env, symbol);
@@ -64,7 +64,7 @@ void SymbolName(Context &ctx, Frame &fp) {
 void SymbolNamespace(Context &ctx, Frame &fp) {
   Tag symbol = fp.argv[0];
 
-  if (!Symbol::IsType(ctx.env, symbol))
+  if (!Symbol::IsType(symbol))
     Exception::Raise(ctx.env, "sy-ns", "error", "type", symbol);
 
   fp.value = Symbol::ns(ctx.env, symbol);

--- a/src/libmu/mu/mu-vector.cc
+++ b/src/libmu/mu/mu-vector.cc
@@ -48,7 +48,7 @@ void VectorRef(Context &ctx, Frame &fp) {
   Tag vector = fp.argv[0];
   Tag index = fp.argv[1];
 
-  if (!Vector::IsType(ctx.env, vector))
+  if (!Vector::IsType(vector))
     Exception::Raise(ctx.env, "sv-ref", "error", "vector", vector);
 
   if (!Fixnum::IsType(index))
@@ -87,7 +87,7 @@ void VectorRef(Context &ctx, Frame &fp) {
 void VectorLength(Context &ctx, Frame &fp) {
   Tag vector = fp.argv[0];
 
-  if (!Vector::IsType(ctx.env, vector))
+  if (!Vector::IsType(vector))
     Exception::Raise(ctx.env, "vc-len", "error", "type", vector);
 
   fp.value = Fixnum(Vector::Length(ctx.env, vector)).tag_;
@@ -99,7 +99,7 @@ void VectorSlice(Context &ctx, Frame &fp) {
   Tag offset = fp.argv[1];
   Tag len = fp.argv[2];
 
-  if (!Vector::IsType(ctx.env, vector))
+  if (!Vector::IsType(vector))
     Exception::Raise(ctx.env, "slice", "error", "type", vector);
 
   if (!Fixnum::IsType(offset))
@@ -113,7 +113,7 @@ void VectorSlice(Context &ctx, Frame &fp) {
 
 /** * (sv-type vector) => symbol **/
 void VectorType(Context &ctx, Frame &fp) {
-  if (!Vector::IsType(ctx.env, fp.argv[0]))
+  if (!Vector::IsType(fp.argv[0]))
     Exception::Raise(ctx.env, "sv-type", "error", "type", fp.argv[0]);
 
   fp.value = Vector::VecType(ctx.env, fp.argv[0]);
@@ -124,10 +124,10 @@ void VectorCons(Context &ctx, Frame &fp) {
   Tag type = fp.argv[0];
   Tag list = fp.argv[1];
 
-  if (!Symbol::IsType(ctx.env, type))
+  if (!Symbol::IsType(type))
     Exception::Raise(ctx.env, "list-sv", "error", "type", type);
 
-  if (!Cons::IsList(ctx.env, list))
+  if (!Cons::IsList(list))
     Exception::Raise(ctx.env, "list-sv", "error", "type", list);
 
   fp.value = Vector::ListToVector(ctx.env, type, list);

--- a/src/libmu/type/char.h
+++ b/src/libmu/type/char.h
@@ -44,7 +44,7 @@ public:
 
   static void Write(Env &env, Tag ch, Tag stream, bool esc) {
     assert(IsType(ch));
-    assert(Stream::IsType(env, stream));
+    assert(Stream::IsType(stream));
 
     if (esc)
       Env::Write(env, "#\\", stream, false);

--- a/src/libmu/type/cons.h
+++ b/src/libmu/type/cons.h
@@ -44,8 +44,8 @@ public: /* tag */
   static Tag car(Env &, Tag);
   static Tag cdr(Env &, Tag);
 
-  static bool IsType(Env &, Tag);
-  static bool IsList(Env &, Tag);
+  static bool IsType(Tag);
+  static bool IsList(Tag);
 
   static Tag List(Env &, const std::vector<Tag> &);
   static Tag ListDot(Env &, const std::vector<Tag> &);
@@ -80,7 +80,7 @@ public: /** * cons iterator **/
 
     iter(Env &env, Tag cons)
         : cons_(Null(cons) ? end() : cons), current_(cons_), env_(env) {
-      assert(IsList(env, cons));
+      assert(IsList(cons));
     }
 
     iterator begin() { return cons_; }
@@ -94,7 +94,7 @@ public: /** * cons iterator **/
 
       /** * this cleverness coutesy of dotted pairs **/
       Tag cdr = Cons::cdr(env_, current_);
-      current_ = IsType(env_, cdr) ? cdr : Type::NIL;
+      current_ = IsType(cdr) ? cdr : Type::NIL;
 
       return *&current_;
     }

--- a/src/libmu/type/exception.cc
+++ b/src/libmu/type/exception.cc
@@ -35,7 +35,7 @@ Tag Exception::Heap(Env &env) {
   if (!alloc.has_value())
     throw std::runtime_error("heap exhausted");
 
-  Tag tag = Entag(alloc.value(), TAG::INDIRECT);
+  Tag tag = Entag(alloc.value(), SYS_CLASS::EXCEPTION, TAG::INDIRECT);
   *env.heap->Layout<Layout>(env, tag) = exception_;
 
   return tag;
@@ -43,7 +43,7 @@ Tag Exception::Heap(Env &env) {
 
 /** * garbage collection **/
 void Exception::Gc(Env &env, Tag exception) {
-  assert(IsType(env, exception));
+  assert(IsType(exception));
 
   if (Env::IsGcMarked(env, exception))
     return;
@@ -56,7 +56,7 @@ void Exception::Gc(Env &env, Tag exception) {
 
 /** * make view of exception **/
 Tag Exception::View(Env &env, Tag ex) {
-  assert(IsType(env, ex));
+  assert(IsType(ex));
 
   std::vector<Tag> view = std::vector<Tag>{tag(env, ex), eclass(env, ex),
                                            etype(env, ex), source(env, ex)};
@@ -66,7 +66,7 @@ Tag Exception::View(Env &env, Tag ex) {
 
 /** * raise exception **/
 void Exception::RaiseException(Env &env, Tag exception) {
-  assert(IsType(env, exception));
+  assert(IsType(exception));
 
   (void)env;
   throw exception;

--- a/src/libmu/type/exception.h
+++ b/src/libmu/type/exception.h
@@ -42,38 +42,37 @@ private:
   Layout exception_;
 
 public:
-  static inline bool IsType(Env &env, Tag ptr) {
-    return IsIndirect(ptr) &&
-           env.heap->SysClass(env, ptr) == SYS_CLASS::EXCEPTION;
+  static inline bool IsType(Tag ptr) {
+    return IsIndirect(ptr) && IndirectClass(ptr) == SYS_CLASS::EXCEPTION;
   }
 
   /** * accessors **/
   static Tag tag(Env &env, Tag exception) {
-    assert(IsType(env, exception));
+    assert(IsType(exception));
 
     return Heap::Layout<Layout>(env, exception)->tag;
   }
 
   static Tag frame(Env &env, Tag exception) {
-    assert(IsType(env, exception));
+    assert(IsType(exception));
 
     return Heap::Layout<Layout>(env, exception)->frame;
   }
 
   static Tag eclass(Env &env, Tag exception) {
-    assert(IsType(env, exception));
+    assert(IsType(exception));
 
     return Heap::Layout<Layout>(env, exception)->eclass;
   }
 
   static Tag etype(Env &env, Tag exception) {
-    assert(IsType(env, exception));
+    assert(IsType(exception));
 
     return Heap::Layout<Layout>(env, exception)->etype;
   }
 
   static Tag source(Env &env, Tag exception) {
-    assert(IsType(env, exception));
+    assert(IsType(exception));
 
     return Heap::Layout<Layout>(env, exception)->source;
   }

--- a/src/libmu/type/fixnum.cc
+++ b/src/libmu/type/fixnum.cc
@@ -31,7 +31,7 @@ namespace type {
 /** * print fixnum to stream **/
 void Fixnum::Write(Env &env, Tag fixnum, Tag stream, bool) {
   assert(IsType(fixnum));
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   std::ostringstream str;
 

--- a/src/libmu/type/float.cc
+++ b/src/libmu/type/float.cc
@@ -31,7 +31,7 @@ namespace type {
 /** * print float object to stream **/
 void Float::Write(Env &env, Tag lfloat, Tag stream, bool) {
   assert(IsType(lfloat));
-  assert(Stream::IsType(env, stream));
+  assert(Stream::IsType(stream));
 
   std::ostringstream str;
 
@@ -41,8 +41,8 @@ void Float::Write(Env &env, Tag lfloat, Tag stream, bool) {
 
 /** * print double object to stream **/
 void Double::Write(Env &env, Tag dbl, Tag stream, bool) {
-  assert(IsType(env, dbl));
-  assert(Stream::IsType(env, stream));
+  assert(IsType(dbl));
+  assert(Stream::IsType(stream));
 
   std::ostringstream str;
 

--- a/src/libmu/type/float.h
+++ b/src/libmu/type/float.h
@@ -76,12 +76,12 @@ public:
   Layout layout_;
 
 public: /* tag */
-  static inline bool IsType(Env &env, Tag ptr) {
-    return IsIndirect(ptr) && env.heap->SysClass(env, ptr) == SYS_CLASS::DOUBLE;
+  static inline bool IsType(Tag ptr) {
+    return IsIndirect(ptr) && IndirectClass(ptr) == SYS_CLASS::DOUBLE;
   }
 
   static double DoubleOf(Env &env, Tag dbl) {
-    assert(IsType(env, dbl));
+    assert(IsType(dbl));
 
     return *(Heap::Layout<double>(env, dbl));
   }
@@ -98,7 +98,7 @@ public: /* type model */
     Layout *layout = reinterpret_cast<Layout *>(alloc.value());
 
     layout->dbl = layout_.dbl;
-    return Entag(alloc.value(), TAG::INDIRECT);
+    return Entag(alloc.value(), SYS_CLASS::DOUBLE, TAG::INDIRECT);
   }
 
 public: /* object */

--- a/src/libmu/type/function.cc
+++ b/src/libmu/type/function.cc
@@ -32,14 +32,13 @@ namespace type {
 
 using SCOPE = Namespace::SCOPE;
 
-bool Function::IsType(Env &env, Tag ptr) {
-  return Type::IsIndirect(ptr) &&
-         env.heap->SysClass(env, ptr) == SYS_CLASS::FUNCTION;
+bool Function::IsType(Tag ptr) {
+  return Type::IsIndirect(ptr) && IndirectClass(ptr) == SYS_CLASS::FUNCTION;
 }
 
 /** * garbage collection **/
 void Function::Gc(Env &env, Tag ptr) {
-  assert(IsType(env, ptr));
+  assert(IsType(ptr));
 
   if (Env::IsGcMarked(env, ptr))
     return;
@@ -52,11 +51,11 @@ void Function::Gc(Env &env, Tag ptr) {
 
 /** * function printer **/
 void Function::Write(Env &env, Tag fn, Tag stream, bool) {
-  assert(IsType(env, fn));
-  assert(Stream::IsType(env, stream));
+  assert(IsType(fn));
+  assert(Stream::IsType(stream));
 
   std::string type = Vector::StdStringOf(
-      env, Symbol::name(env, Type::MapClassSymbol(Type::TypeOf(env, fn))));
+      env, Symbol::name(env, Type::MapClassSymbol(Type::TypeOf(fn))));
 
   std::string ns =
       Function::IsNative(env, fn)
@@ -95,7 +94,7 @@ void Function::Write(Env &env, Tag fn, Tag stream, bool) {
 
 /** * make view of function **/
 Tag Function::View(Env &env, Tag fn) {
-  assert(IsType(env, fn));
+  assert(IsType(fn));
 
   std::vector<Tag> view = std::vector<Tag>{
       arity(env, fn), form(env, fn), frame_id(env, fn), extension(env, fn)};
@@ -109,7 +108,7 @@ Tag Function::Heap(Env &env) {
   if (!alloc.has_value())
     throw std::runtime_error("heap exhausted");
 
-  Tag tag = Entag(alloc.value(), TAG::INDIRECT);
+  Tag tag = Entag(alloc.value(), SYS_CLASS::FUNCTION, TAG::INDIRECT);
   *env.heap->Layout<Layout>(env, tag) = function_;
 
   return tag;
@@ -117,7 +116,7 @@ Tag Function::Heap(Env &env) {
 
 /** * clone function object **/
 Tag Function::Clone(Env &env, Tag view) {
-  assert(Vector::IsType(env, view));
+  assert(Vector::IsType(view));
 
   Function fn = Function();
 

--- a/src/libmu/type/function.h
+++ b/src/libmu/type/function.h
@@ -47,40 +47,40 @@ public:
   Layout function_;
 
 public: /* tag */
-  static bool IsType(Env &, Tag);
+  static bool IsType(Tag);
 
   static bool IsNative(Env &env, Tag fn) {
-    return Symbol::IsType(env, form(env, fn));
+    return Symbol::IsType(form(env, fn));
   }
 
   /* accessors */
   static Tag arity(Env &env, Tag fn) {
-    assert(IsType(env, fn));
+    assert(IsType(fn));
 
     return Heap::Layout<Layout>(env, fn)->arity;
   }
 
   static Tag form(Env &env, Tag fn) {
-    assert(IsType(env, fn));
+    assert(IsType(fn));
 
     return Heap::Layout<Layout>(env, fn)->form;
   }
 
   static Tag set_form(Env &env, Tag fn, Tag form) {
-    assert(IsType(env, fn));
+    assert(IsType(fn));
 
     Heap::Layout<Layout>(env, fn)->form = form;
     return form;
   }
 
   static Tag frame_id(Env &env, Tag fn) {
-    assert(IsType(env, fn));
+    assert(IsType(fn));
 
     return Heap::Layout<Layout>(env, fn)->frame_id;
   }
 
   static Tag extension(Env &env, Tag fn) {
-    assert(IsType(env, fn));
+    assert(IsType(fn));
 
     return Heap::Layout<Layout>(env, fn)->extension;
   }
@@ -106,8 +106,8 @@ public: /* object */
   }
 
   explicit Function(Env &env, Tag id, Tag lambda, Tag form) : Type() {
-    assert(Cons::IsList(env, lambda));
-    assert(Cons::IsList(env, form));
+    assert(Cons::IsList(lambda));
+    assert(Cons::IsList(form));
 
     function_.arity = Fixnum(Cons::Length(env, lambda)).tag_;
     function_.form = form;

--- a/src/libmu/type/namespace.h
+++ b/src/libmu/type/namespace.h
@@ -53,43 +53,43 @@ private:
 public: /* tag */
   enum class SCOPE : bool { EXTERN, INTERN };
 
-  static bool IsType(Env &, Tag);
+  static bool IsType(Tag);
 
   static Tag NsDesignator(Env &, Tag);
 
   /** * accessors **/
   static Tag name(Env &env, Tag ns) {
-    assert(IsType(env, ns));
+    assert(IsType(ns));
 
     return Heap::Layout<Layout>(env, ns)->name;
   }
 
   static Tag import(Env &env, Tag ns) {
-    assert(IsType(env, ns));
+    assert(IsType(ns));
 
     return Heap::Layout<Layout>(env, ns)->import;
   }
 
   static Tag externs(Env &env, Tag ns) {
-    assert(IsType(env, ns));
+    assert(IsType(ns));
 
     return Heap::Layout<Layout>(env, ns)->externs;
   }
 
   static Tag interns(Env &env, Tag ns) {
-    assert(IsType(env, ns));
+    assert(IsType(ns));
 
     return Heap::Layout<Layout>(env, ns)->interns;
   }
 
   static void externs(Env &env, Tag ns, Tag value) {
-    assert(IsType(env, ns));
+    assert(IsType(ns));
 
     Heap::Layout<Layout>(env, ns)->externs = value;
   }
 
   static void interns(Env &env, Tag ns, Tag value) {
-    assert(IsType(env, ns));
+    assert(IsType(ns));
 
     Heap::Layout<Layout>(env, ns)->interns = value;
   }

--- a/src/libmu/type/stream.cc
+++ b/src/libmu/type/stream.cc
@@ -37,14 +37,14 @@ using Heap = core::Heap;
 namespace type {
 
 /** * type predicate **/
-bool Stream::IsType(Env &env, Tag ptr) {
+bool Stream::IsType(Tag ptr) {
   return Type::IsIndirect(ptr) &&
-         env.heap->SysClass(env, ptr) == Type::SYS_CLASS::STREAM;
+         Type::IndirectClass(ptr) == Type::SYS_CLASS::STREAM;
 }
 
 /** * view of stream object **/
 Tag Stream::View(Env &env, Tag sp) {
-  assert(IsType(env, sp));
+  assert(IsType(sp));
 
   std::vector<Tag> view =
       std::vector<Tag>{Fixnum(reinterpret_cast<size_t>(stream(env, sp))).tag_};
@@ -54,7 +54,7 @@ Tag Stream::View(Env &env, Tag sp) {
 
 /** * stream eof predicate **/
 bool Stream::IsEof(Env &env, Tag sp) {
-  assert(Stream::IsType(env, sp));
+  assert(Stream::IsType(sp));
   assert(stream(env, sp)->IsInput());
 
   return stream(env, sp)->IsEof();
@@ -62,14 +62,14 @@ bool Stream::IsEof(Env &env, Tag sp) {
 
 /** * stream closed predicate **/
 bool Stream::IsClosed(Env &env, Tag sp) {
-  assert(Stream::IsType(env, sp));
+  assert(Stream::IsType(sp));
 
   return stream(env, sp)->IsClosed();
 }
 
 /** * flush stream **/
 void Stream::Flush(Env &env, Tag sp) {
-  assert(IsType(env, sp));
+  assert(IsType(sp));
   assert(stream(env, sp)->IsOutput());
 
   stream(env, sp)->Flush();
@@ -78,7 +78,7 @@ void Stream::Flush(Env &env, Tag sp) {
 /** * unread char from stream **/
 Tag Stream::UnReadByte(Env &env, Tag byte, Tag sp) {
   assert(Fixnum::IsType(byte));
-  assert(Stream::IsType(env, sp));
+  assert(Stream::IsType(sp));
   assert(stream(env, sp)->IsInput());
 
   stream(env, sp)->UnReadByte(Fixnum::Int64Of(byte));
@@ -89,7 +89,7 @@ Tag Stream::UnReadByte(Env &env, Tag byte, Tag sp) {
 /** * write byte to stream **/
 void Stream::WriteByte(Env &env, Tag byte, Tag sp) {
   assert(Fixnum::IsType(byte));
-  assert(Stream::IsType(env, sp));
+  assert(Stream::IsType(sp));
   assert(stream(env, sp)->IsOutput());
 
   stream(env, sp)->WriteByte(static_cast<int>(Fixnum::Int64Of(byte)));
@@ -97,7 +97,7 @@ void Stream::WriteByte(Env &env, Tag byte, Tag sp) {
 
 /** * read byte from stream, returns a fixnum or nil **/
 Tag Stream::ReadByte(Env &env, Tag sp) {
-  assert(IsType(env, sp));
+  assert(IsType(sp));
   assert(stream(env, sp)->IsOutput());
 
   std::optional<int> byte = stream(env, sp)->ReadByte();
@@ -108,7 +108,7 @@ Tag Stream::ReadByte(Env &env, Tag sp) {
 /** * unread char from stream **/
 Tag Stream::UnReadChar(Env &env, Tag ch, Tag sp) {
   assert(Char::IsType(ch));
-  assert(Stream::IsType(env, sp));
+  assert(Stream::IsType(sp));
   assert(stream(env, sp)->IsInput());
 
   stream(env, sp)->UnReadByte(static_cast<int64_t>(Char::UInt64Of(ch)));
@@ -119,7 +119,7 @@ Tag Stream::UnReadChar(Env &env, Tag ch, Tag sp) {
 /** * write char to stream **/
 void Stream::WriteChar(Env &env, Tag ch, Tag sp) {
   assert(Char::IsType(ch));
-  assert(Stream::IsType(env, sp));
+  assert(Stream::IsType(sp));
   assert(stream(env, sp)->IsOutput());
 
   stream(env, sp)->WriteByte(static_cast<int>(Char::UInt64Of(ch)));
@@ -127,7 +127,7 @@ void Stream::WriteChar(Env &env, Tag ch, Tag sp) {
 
 /** * read char from stream, returns a char or nil **/
 Tag Stream::ReadChar(Env &env, Tag sp) {
-  assert(IsType(env, sp));
+  assert(IsType(sp));
   assert(stream(env, sp)->IsInput());
 
   std::optional<int> byte = stream(env, sp)->ReadByte();
@@ -137,7 +137,7 @@ Tag Stream::ReadChar(Env &env, Tag sp) {
 
 /** * close stream **/
 Tag Stream::Close(Env &env, Tag sp) {
-  assert(IsType(env, sp));
+  assert(IsType(sp));
 
   stream(env, sp)->Close();
   return T;
@@ -150,7 +150,7 @@ Tag Stream::Heap(Env &env) {
 
   *reinterpret_cast<Layout *>(env.heap->HeapAddr(alloc.value())) = stream_;
 
-  return Entag(alloc.value(), TAG::INDIRECT);
+  return Entag(alloc.value(), SYS_CLASS::STREAM, TAG::INDIRECT);
 }
 
 Stream::Stream(system::Stream *stream) : Type() { stream_.stream = stream; }

--- a/src/libmu/type/stream.h
+++ b/src/libmu/type/stream.h
@@ -42,10 +42,10 @@ private:
   Layout stream_;
 
 public: /* tag */
-  static bool IsType(Env &, Tag);
+  static bool IsType(Tag);
 
   static system::Stream *stream(Env &env, Tag stream) {
-    assert(IsType(env, stream));
+    assert(IsType(stream));
 
     return Heap::Layout<Layout>(env, stream)->stream;
   }

--- a/src/libmu/type/symbol.cc
+++ b/src/libmu/type/symbol.cc
@@ -62,9 +62,9 @@ Tag name_of(Env &env, const std::string &symbol, const std::string &sep) {
 
 } /* anonymous namespace */
 
-bool Symbol::IsType(Env &env, Tag ptr) {
+bool Symbol::IsType(Tag ptr) {
   return IsKeyword(ptr) ||
-         (IsIndirect(ptr) && env.heap->SysClass(env, ptr) == SYS_CLASS::SYMBOL);
+         (IsIndirect(ptr) && IndirectClass(ptr) == SYS_CLASS::SYMBOL);
 }
 
 Tag Symbol::ns(Env &env, Tag symbol) {
@@ -78,7 +78,7 @@ Tag Symbol::ns(Env &env, Tag symbol) {
 
 /** * garbage collection **/
 void Symbol::Gc(Env &env, Tag ptr) {
-  assert(IsType(env, ptr));
+  assert(IsType(ptr));
 
   if (IsKeyword(ptr) || Env::IsGcMarked(env, ptr))
     return;
@@ -102,14 +102,14 @@ Tag Symbol::Keyword(const std::string &name) {
 
 /** * is symbol bound to a value? */
 bool Symbol::IsBound(Env &env, Tag sym) {
-  assert(IsType(env, sym));
+  assert(IsType(sym));
 
   return IsKeyword(sym) || !Eq(value(env, sym), UNBOUND);
 }
 
 /** * is symbol not interned? */
 bool Symbol::IsUninterned(Env &env, Tag sym) {
-  assert(IsType(env, sym));
+  assert(IsType(sym));
 
   if (IsKeyword(sym))
     return false;
@@ -119,8 +119,8 @@ bool Symbol::IsUninterned(Env &env, Tag sym) {
 
 /** * print symbol to stream **/
 void Symbol::Write(Env &env, Tag sym, Tag stream, bool esc) {
-  assert(IsType(env, sym));
-  assert(Stream::IsType(env, stream));
+  assert(IsType(sym));
+  assert(Stream::IsType(stream));
 
   if (IsKeyword(sym)) {
     Env::Write(env, ":", stream, false);
@@ -188,7 +188,7 @@ Tag Symbol::Heap(Env &env) {
   if (!alloc.has_value())
     throw std::runtime_error("heap exhausted");
 
-  Tag tag = Entag(alloc.value(), TAG::INDIRECT);
+  Tag tag = Entag(alloc.value(), SYS_CLASS::SYMBOL, TAG::INDIRECT);
   *env.heap->Layout<Layout>(env, tag) = symbol_;
 
   return tag;

--- a/src/libmu/type/symbol.h
+++ b/src/libmu/type/symbol.h
@@ -45,7 +45,7 @@ private:
 public: /* tag */
   Heap::HeapInfo heapinfo() { return heapinfo_; }
 
-  static bool IsType(Env &, Tag);
+  static bool IsType(Tag);
 
   /* Keywords */
   static inline bool IsKeyword(Tag ptr) {
@@ -59,21 +59,21 @@ public: /* tag */
   static Tag ns(Env &, Tag);
 
   static Tag value(Env &env, Tag symbol) {
-    assert(IsType(env, symbol));
+    assert(IsType(symbol));
 
     return IsKeyword(symbol) ? symbol
                              : Heap::Layout<Layout>(env, symbol)->value;
   }
 
   static Tag set_value(Env &env, Tag symbol, Tag value) {
-    assert(IsType(env, symbol));
+    assert(IsType(symbol));
 
     return IsKeyword(symbol) ? symbol
                              : Heap::Layout<Layout>(env, symbol)->value = value;
   }
 
   static Tag name(Env &env, Tag symbol) {
-    assert(IsType(env, symbol));
+    assert(IsType(symbol));
 
     return IsKeyword(symbol)
                ? MakeDirect(DirectData(symbol), DirectSize(symbol),

--- a/src/libmu/type/vector.h
+++ b/src/libmu/type/vector.h
@@ -48,7 +48,7 @@ public:
 
 public: /* string */
   static std::string StdStringOf(Env &env, Tag str) {
-    assert(IsType(env, str));
+    assert(IsType(str));
 
     return std::string{Data<char>(env, str), Length(env, str)};
   }
@@ -90,18 +90,18 @@ public: /* Tag */
   }
 
   static Tag Map(Env &, Tag, Tag);
-  static bool IsType(Env &, Tag);
+  static bool IsType(Tag);
 
   static inline bool IsTyped(Env &env, Tag ptr, SYS_CLASS vtype) {
     return (IsDirect(ptr) && (DirectClass(ptr) == DIRECT_CLASS::VECTOR) &&
             (vtype == SYS_CLASS::CHAR)) ||
-           (IsType(env, ptr) && (type(env, ptr) == vtype));
+           (IsType(ptr) && (type(env, ptr) == vtype));
   }
 
   static void *DataV(Env &, Tag &);
 
   template <typename T> static T *Data(Env &env, Tag &vector) {
-    assert(IsType(env, vector));
+    assert(IsType(vector));
 
     return IsDirect(vector)
                ? reinterpret_cast<T *>(reinterpret_cast<uint8_t *>(&vector) + 1)
@@ -109,13 +109,13 @@ public: /* Tag */
   }
 
   template <typename T> static inline T Ref(Env &env, Tag &vector, int index) {
-    assert(IsType(env, vector));
+    assert(IsType(vector));
 
     return Data<T>(env, vector)[index];
   }
 
   static size_t inline Length(Env &env, Tag vec) {
-    assert(IsType(env, vec));
+    assert(IsType(vec));
 
     return (IsDirect(vec) && DirectClass(vec) == DIRECT_CLASS::VECTOR)
                ? DirectSize(vec)
@@ -123,7 +123,7 @@ public: /* Tag */
   }
 
   static SYS_CLASS inline TypeOf(Env &env, Tag vec) {
-    assert(IsType(env, vec));
+    assert(IsType(vec));
 
     return (IsDirect(vec) && DirectClass(vec) == DIRECT_CLASS::VECTOR
                 ? SYS_CLASS::CHAR
@@ -131,7 +131,7 @@ public: /* Tag */
   }
 
   static inline Tag VecType(Env &env, Tag vec) {
-    assert(IsType(env, vec));
+    assert(IsType(vec));
 
     return Type::MapClassSymbol(TypeOf(env, vec));
   }


### PR DESCRIPTION
Put the type tag back in the generic tag

Practically eliminates GetHeapInfo calls, our top functions are now eval and cdr. No perceptible performance impact.